### PR TITLE
Update line height for prose

### DIFF
--- a/_assets/styles/global.scss
+++ b/_assets/styles/global.scss
@@ -72,7 +72,7 @@ h2 {
 
 .prose {
   font-size: 16px;
-  line-height: 24px;
+  line-height: 26px;
 }
 
 .prose p, ul, ol {


### PR DESCRIPTION
Mainly to give a bit more space for the underlining which intrudes a bit
following the font change.

@yanneves ok with you?