### PR TITLE
Try using the old travis environment to fix 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ deploy:
     branch: master
 env:
   - GA_KEY="UA-2150808-14"
+group: deprecated-2017Q4


### PR DESCRIPTION
The website is 404'ing after each new build, including previously good
builds. This change tries to roll back to a previous Travis environment,
as that is the only thing which is different. See
https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch