### PR TITLE
#178 "Previous Event" and "Following Event" are mismatched

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -11,11 +11,11 @@
       <section class="column past-events">
         <h2 class="module-heading">Previous Event:</h2>
         <ul class="event-listing">
-          {{#with previous}}
-            <li class="event-item">{{> eventItem }}</li>
+          {{#with next}}
+          <li class="event-item">{{> eventItem }}</li>
           {{/with}}
-          {{#unless previous}}
-            <li class="empty">This is the last event</li>
+          {{#unless next}}
+          <li class="empty">This is the most recent event</li>
           {{/unless}}
         </ul>
         <p class="read-more"><a href="/events/">View all events</a></p>
@@ -23,11 +23,11 @@
       <section class="column upcoming-events">
         <h2 class="module-heading">Following Event:</h2>
         <ul class="event-listing">
-          {{#with next}}
-            <li class="event-item">{{> eventItem }}</li>
+          {{#with previous}}
+          <li class="event-item">{{> eventItem }}</li>
           {{/with}}
-          {{#unless next}}
-            <li class="empty">This is the most recent event</li>
+          {{#unless previous}}
+          <li class="empty">This is the last event</li>
           {{/unless}}
         </ul>
         <p class="read-more"><a href="/events/">View all events</a></p>


### PR DESCRIPTION
I interchanged the order between 'previous' and 'next' event sections in the event.html file. Please let me know if this is the right fix. I tested the change locally on the 'firebase', 'ruby-rocks' and 'ask-the-brain' pages.

 Thank you. 
  