### PR TITLE
fix title double encode

### DIFF
--- a/_includes/partials/head.html
+++ b/_includes/partials/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
   <meta name="google-site-verification" content="i7Zcd4VE6mdqs2t1pb_kquaAQI_WItbWMOAt7_t0AYo" />
-  <title>{{#if title}}{{ title }} &ndash; {{ site.title }}{{/if}}{{#unless title}}{{ site.title }}: {{ striptags (markdown site.caption) }}{{/unless}}</title>
+  <title>{{#if title}}{{ title }} &ndash; {{ site.title }}{{/if}}{{#unless title}}{{ site.title }}: {{{ striptags (markdown site.caption) }}}{{/unless}}</title>
   <link rel="author" href="/humans.txt">
   <link rel="shortcut icon" href="/img/favicon.png" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Catamaran:400,700|Anton">


### PR DESCRIPTION
This fixes the page title double encode issue.

If you google "async brighton", you'll see the title as "Async: A Web Tech Meetup for Brighton **&amp;amp;** Hove". This fixes the issue there and in the HTML page title.