### PR TITLE
fix: Replaced broken images hosted on Async website

### DIFF
--- a/_posts/2012-04-12-architecture.md
+++ b/_posts/2012-04-12-architecture.md
@@ -14,7 +14,7 @@ speakers:
 sponsors:
 - name: Brandwatch
   link: http://www.brandwatch.com
-  logo: /images/sponsors/brandwatch.png
+  logo: /img/sponsors/brandwatch.png
 tags:
 - architecture
 - backbonejs

--- a/_posts/2012-04-26-birthday2.md
+++ b/_posts/2012-04-26-birthday2.md
@@ -6,7 +6,7 @@ speakers:
 sponsors:
 - name: Brandwatch
   link: http://www.brandwatch.com
-  logo: /images/sponsors/brandwatch.png
+  logo: /img/sponsors/brandwatch.png
 image: 
   url: http://farm4.staticflickr.com/3192/2941676828_07b19d1699.jpg
   title: Title? by Chaval Brasil, on Flickr

--- a/_posts/2012-05-24-hypermedia.md
+++ b/_posts/2012-05-24-hypermedia.md
@@ -9,7 +9,7 @@ speakers:
 sponsors:
 - name: Brandwatch
   link: http://www.brandwatch.com
-  logo: /images/sponsors/brandwatch.png
+  logo: /img/sponsors/brandwatch.png
 image:
   url:   http://farm1.staticflickr.com/104/265106093_72262a959a.jpg
   title: Colors And Numbers by cszar, on Flickr

--- a/_posts/2012-09-13-onecanvas.md
+++ b/_posts/2012-09-13-onecanvas.md
@@ -45,7 +45,7 @@ This is a fun, relaxed, no-experience-necessary event to learn and play with new
 [#jj]: http://jungle.asyncjs.com
 [#jjblog]: https://asyncjs.com/the-mighty-jungle/
 [#bdf]: http://brightondigitalfestival.co.uk
-[#bdf-logo]: https://asyncjs.com/images/bdf-2012-logo-small.png "A Brighton Digital Festival event"
+[#bdf-logo]: https://asyncjs.com/img/bdf-2012-logo-small.png "A Brighton Digital Festival event"
 [#bdf-onecanvas]: http://2012.brightondigitalfestival.co.uk/event/asyncs-one-canvas-hack-night-part-one-2/
 [#onecanvas]: https://asyncjs.com/onecanvas/
 [#onecanvas2]: https://asyncjs.com/onecanvas-2/

--- a/_posts/2012-09-27-onecanvas-2.md
+++ b/_posts/2012-09-27-onecanvas-2.md
@@ -45,7 +45,7 @@ This is a fun, relaxed, no-experience-necessary event to learn and play with new
 [#jj]: http://jungle.asyncjs.com
 [#jjblog]: https://asyncjs.com/the-mighty-jungle/
 [#bdf]: http://brightondigitalfestival.co.uk
-[#bdf-logo]: https://asyncjs.com/images/bdf-2012-logo-small.png "A Brighton Digital Festival event"
+[#bdf-logo]: https://asyncjs.com/img/bdf-2012-logo-small.png "A Brighton Digital Festival event"
 [#bdf-onecanvas]: http://2012.brightondigitalfestival.co.uk/event/asyncs-one-canvas-hack-night-part-two/
 [#onecanvas]: https://asyncjs.com/onecanvas/
 [#onecanvas2]: https://asyncjs.com/onecanvas-2/

--- a/_posts/2013-08-08-workers.md
+++ b/_posts/2013-08-08-workers.md
@@ -8,7 +8,7 @@ speakers:
   link: http://hyperlounge.com
 sponsors:
 image:
-  url:   /images/talks/worker.jpg
+  url:   /img/talks/worker.jpg
   title: "A coal miner in Stalino"
   link:  http://http://lewis-hughes.co.uk/post/28989769320/1bohemian-a-coal-miner-in-stalino-donetsk
 tags:

--- a/_posts/2013-08-22-server-sent-events.md
+++ b/_posts/2013-08-22-server-sent-events.md
@@ -8,7 +8,7 @@ speakers:
   link: "http://kornel.lesinski.name"
 sponsors:
 image:
-  url:   /images/talks/class-header-connectivity.jpg
+  url:   /img/talks/class-header-connectivity.jpg
   title: "Server-Sent Events spec (image CC-BY-SA by W3C)"
   link:  http://www.w3.org/TR/eventsource/
 tags:

--- a/_posts/2013-09-12-nodeventure.md
+++ b/_posts/2013-09-12-nodeventure.md
@@ -8,7 +8,7 @@ speakers:
   link:
 sponsors:
 image:
-  url:   /images/talks/nodeventure-text.jpg
+  url:   /img/talks/nodeventure-text.jpg
   title: "Nodeventure"
   link:
 tags:

--- a/_posts/2013-09-26-nodeventure2.md
+++ b/_posts/2013-09-26-nodeventure2.md
@@ -8,7 +8,7 @@ speakers:
   link:
 sponsors:
 image:
-  url:   /images/talks/nodeventure-text.jpg
+  url:   /img/talks/nodeventure-text.jpg
   title: "Nodeventure"
   link:
 tags:

--- a/_posts/2013-10-10-be-more-hapi.md
+++ b/_posts/2013-10-10-be-more-hapi.md
@@ -7,7 +7,7 @@ speakers:
 - name: Glenn Jones
   link: http://glennjones.net
 image:
-  url:   /images/talks/happycomputer.jpg
+  url:   /img/talks/happycomputer.jpg
   title: "'Happy computer' by Karsten Schmidt"
   link:  http://www.flickr.com/photos/toxi/3489976711/
 tags:

--- a/_posts/2013-11-07-showntell-2013.md
+++ b/_posts/2013-11-07-showntell-2013.md
@@ -23,7 +23,7 @@ venue:
 sponsors:
 - name: Dharmafly
   link: http://dharmafly.com
-  logo: /images/sponsors/dharmafly.png
+  logo: /img/sponsors/dharmafly.png
 layout: event.html
 collection: events
 ---

--- a/_posts/2015-09-10-playcanvas-hacknight-part-1.md
+++ b/_posts/2015-09-10-playcanvas-hacknight-part-1.md
@@ -4,7 +4,7 @@ summary: "A JavaScript Meetup for Brighton and Hove"
 date: 2015-09-10T19:15:00
 lanyrd: http://lanyrd.com/2015/async-playcanvas-hacknight-part-1
 image:
-  url:   /images/talks/spaceships_asteroids.png
+  url:   /img/talks/spaceships_asteroids.png
   title: "Lunar Lander"
   link:  http://playcanvas.com
 tags:

--- a/_posts/2015-09-24-playcanvas-hacknight-part-2.md
+++ b/_posts/2015-09-24-playcanvas-hacknight-part-2.md
@@ -4,7 +4,7 @@ summary: "A JavaScript Meetup for Brighton and Hove"
 date: 2015-09-24T19:15:00
 lanyrd: http://lanyrd.com/2015/async-playcanvas-hacknight-part-2
 image:
-  url:   /images/talks/spaceships_asteroids.png
+  url:   /img/talks/spaceships_asteroids.png
   title: "Lunar Lander"
   link:  http://playcanvas.com
 tags:

--- a/_posts/2016-06-09-make-your-own-js-game.md
+++ b/_posts/2016-06-09-make-your-own-js-game.md
@@ -13,7 +13,7 @@ image:
 sponsors:
 - name: Brandwatch
   link: https://www.brandwatch.com/careers
-  logo: /images/sponsors/brandwatch.png
+  logo: /img/sponsors/brandwatch.png
 tags:
 - games
 - js

--- a/_posts/2016-06-23-glenn-jones.md
+++ b/_posts/2016-06-23-glenn-jones.md
@@ -13,7 +13,7 @@ image:
 sponsors:
 - name: Pusher
   link: https://www.pusher.com
-  logo: /images/sponsors/pusher.png
+  logo: /img/sponsors/pusher.png
 tags:
 venue:
   name: 68 Middle St

--- a/_posts/2016-08-11-twofer-games-and-bots.md
+++ b/_posts/2016-08-11-twofer-games-and-bots.md
@@ -10,7 +10,7 @@ speakers:
   link: https://twitter.com/CarlBateman
 sponsors:
 image:
-  url:   /images/talks/doublebill.png
+  url:   /img/talks/doublebill.png
   title: "Double Bill"
 tags:
   - js

--- a/_posts/2016-09-08-fishcotheque.md
+++ b/_posts/2016-09-08-fishcotheque.md
@@ -8,9 +8,9 @@ speakers:
 lanyrd: https://lanyrd.com/2016/asyncjs-fishcotheque-1-of-2
 sponsors:
 image:
-  url:   /images/talks/fishcotheque.jpg
+  url:   /img/talks/fishcotheque.jpg
   title: Fishcotheque
-  link:  /images/talks/fishcotheque.jpg
+  link:  /img/talks/fishcotheque.jpg
 tags:
   - js
   - node

--- a/_posts/2016-09-22-fishcotheque-part-2.md
+++ b/_posts/2016-09-22-fishcotheque-part-2.md
@@ -8,9 +8,9 @@ speakers:
 lanyrd: https://lanyrd.com/2016/asyncjs-fishcotheque-2-of-2
 sponsors:
 image:
-  url:   /images/talks/fishcotheque.jpg
+  url:   /img/talks/fishcotheque.jpg
   title: Fishcotheque
-  link:  /images/talks/fishcotheque.jpg
+  link:  /img/talks/fishcotheque.jpg
 tags:
   - js
   - node

--- a/_posts/2016-10-06-make-your-own-js-game-pt-2.md
+++ b/_posts/2016-10-06-make-your-own-js-game-pt-2.md
@@ -13,7 +13,7 @@ image:
 sponsors:
 - name: Brandwatch
   link: https://www.brandwatch.com/careers
-  logo: /images/sponsors/brandwatch.png
+  logo: /img/sponsors/brandwatch.png
 tags:
 - games
 - js

--- a/_posts/2016-11-03-neural-networks.md
+++ b/_posts/2016-11-03-neural-networks.md
@@ -7,7 +7,7 @@ speakers:
 - name: Antonio De Luca
   link: http://www.antoniodeluca.info/
 image:
-  url: /images/talks/neuralNetworksForSquirrels.jpg
+  url: /img/talks/neuralNetworksForSquirrels.jpg
   title: Neural Networks for Squirrels
 sponsors:
 tags:

--- a/_posts/2017-02-02-how-to-build-a-bot.md
+++ b/_posts/2017-02-02-how-to-build-a-bot.md
@@ -6,7 +6,7 @@ lanyrd: https://lanyrd.com/2017/asyncjs-how-to-build-a-bot
 speakers:
 - name: Alexandre Nicol
 image:
-  url: /images/talks/riseOfTheBots.jpg
+  url: /img/talks/riseOfTheBots.jpg
   title: Artificial Intelligence
   link: https://pixabay.com/p-503588/?no_redirect
 sponsors:

--- a/_posts/2019-11-07-international-show-n-tell-2019.md
+++ b/_posts/2019-11-07-international-show-n-tell-2019.md
@@ -13,7 +13,7 @@ speakers:
 sponsors:
   - name: Brandwatch
     link: http://www.brandwatch.com
-    logo: /images/sponsors/brandwatch.png
+    logo: /img/sponsors/brandwatch.png
 tags:
   - showntell
   - javascript


### PR DESCRIPTION
Changes image paths using /images/ to /img/ to match build output, it appears many event images have been broken a while