### PR TITLE
Alexa to the rescue of inaccessible websites.

### DIFF
--- a/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
+++ b/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
@@ -1,0 +1,33 @@
+---
+title: "Alexa to the rescue of inaccessible websites"
+summary: "This is the tale of how Alexa, with a little bit of help, came to the rescue of a blind person who could not get access to local news."
+date: 2023-02-02T19:15:00
+meetup: https://www.meetup.com/Async-Web-Tech-Meetup/
+speakers:
+- name: "Alex Nicol"
+  link: https://alexnicol.dev
+sponsors:
+image:
+  url:   https://live.staticflickr.com/4045/4682461024_10ce18b9ea_b.jpg
+  title: "HAL in vector by abelmon007 is licensed under CC BY 2.0."
+  link:  https://www.flickr.com/photos/80265839@N00/4682461024
+tags:
+- alexa
+- accessibility
+- ruby
+- aws
+venue:
+  name: TBC?
+layout: event.html
+collection: events
+draft: true # Delete this line to publish
+---
+
+The Web is over 30 years old, yet some websites are still not accessible.
+
+This is the tale of how Alexa, with a little bit of help, came to the rescue of
+a blind person who could not get access to local news.
+
+In this talk, Alex Nicol speaks about accessibility, web crawling, tech for
+good, Alexa, running Ruby on Lambdas, and working on a side project whilst
+having a six-month-old baby.

--- a/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
+++ b/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
@@ -16,18 +16,23 @@ tags:
 - accessibility
 - ruby
 - aws
+- crawler
 venue:
   name: TBC?
 layout: event.html
 collection: events
 draft: true # Delete this line to publish
+online: true
 ---
 
 The Web is over 30 years old, yet some websites are still not accessible.
 
-This is the tale of how Alexa, with a little bit of help, came to the rescue of
-a blind person who could not get access to local news.
+This is the tale of how Alexa, with a little bit of help, came to the rescue of a blind person who could not get access to local news.
 
-In this talk, Alex Nicol speaks about accessibility, web crawling, tech for
-good, Alexa, running Ruby on Lambdas, and working on a side project whilst
-having a six-month-old baby.
+In this talk, Alex Nicol speaks about accessibility, web crawling, tech-for-good, Alexa, running Ruby on Lambdas, and working on a side project whilst having a six-month-old baby.
+
+Alex Nicol is a web developer working at [BridgeU](https://bridge-u.com/) and [Bounce Technologies](https://www.bouncetechnologies.com/). He's also founded is [own consultancy company](https://alexnicol.dev), specialised in conversational systems and tech-for-good. He previously spent six years at EDF Energy as an R&D engineer specialising in automated voice systems and chatbots.
+
+You will be able to join us in-person at [Spaces](https://www.spacesworks.com/brighton/trafalgar-place/), or online (via Zoom).
+
+If you're thinking of joining us in-person, please sign up to the event on [meetup.com](https://www.meetup.com/async-web-tech-meetup/events/288819953/). We also highly recommend you sign up to the [Async Slack](https://join.slack.com/t/asyncjs/shared_invite/zt-1aguxx86q-XjF_yWcFoJ8fyYYzoqgDaQ) for more info, and updates.

--- a/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
+++ b/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
@@ -2,7 +2,7 @@
 title: "Alexa to the rescue of inaccessible websites"
 summary: "This is the tale of how Alexa, with a little bit of help, came to the rescue of a blind person who could not get access to local news."
 date: 2023-02-02T19:15:00
-meetup: https://www.meetup.com/Async-Web-Tech-Meetup/
+meetup: https://www.meetup.com/async-web-tech-meetup/events/291255649/
 speakers:
 - name: "Alex Nicol"
   link: https://alexnicol.dev
@@ -39,4 +39,4 @@ Alex Nicol is a web developer working at [BridgeU](https://bridge-u.com/) and [B
 
 You will be able to join us in-person at [Spaces](https://www.spacesworks.com/brighton/trafalgar-place/), or online (via Zoom).
 
-If you're thinking of joining us in-person, please sign up to the event on [meetup.com](https://www.meetup.com/async-web-tech-meetup/events/288819953/). We also highly recommend you sign up to the [Async Slack](https://join.slack.com/t/asyncjs/shared_invite/zt-1aguxx86q-XjF_yWcFoJ8fyYYzoqgDaQ) for more info, and updates.
+If you're thinking of joining us in-person, please sign up to the event on [meetup.com](https://www.meetup.com/async-web-tech-meetup/events/291255649/). We also highly recommend you sign up to the [Async Slack](https://join.slack.com/t/asyncjs/shared_invite/zt-1aguxx86q-XjF_yWcFoJ8fyYYzoqgDaQ) for more info, and updates.

--- a/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
+++ b/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
@@ -31,7 +31,7 @@ This is the tale of how Alexa, with a little bit of help, came to the rescue of 
 
 In this talk, Alex Nicol speaks about accessibility, web crawling, tech-for-good, Alexa, running Ruby on Lambdas, and working on a side project whilst having a six-month-old baby.
 
-Alex Nicol is a web developer working at [BridgeU](https://bridge-u.com/) and [Bounce Technologies](https://www.bouncetechnologies.com/). He's also founded is [own consultancy company](https://alexnicol.dev), specialised in conversational systems and tech-for-good. He previously spent six years at EDF Energy as an R&D engineer specialising in automated voice systems and chatbots.
+Alex Nicol is a web developer working at [BridgeU](https://bridge-u.com/) and [Bounce Technologies](https://www.bouncetechnologies.com/). He's also founded his [own consultancy company](https://alexnicol.dev), specialised in conversational systems and tech-for-good. He previously spent six years at EDF Energy as an R&D engineer specialising in automated voice systems and chatbots.
 
 You will be able to join us in-person at [Spaces](https://www.spacesworks.com/brighton/trafalgar-place/), or online (via Zoom).
 

--- a/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
+++ b/_posts/2023-02-02-alexa-rescues-inaccessible-sites.md
@@ -18,7 +18,11 @@ tags:
 - aws
 - crawler
 venue:
-  name: TBC?
+  name: Spaces
+  link: https://www.spacesworks.com/brighton/trafalgar-place/
+  location: https://g.page/Mocatta-House-4437?share
+  address: Mocatta House, Trafalgar Pl, BN1 4DU, Brighton
+  latlong: 50.8294399,-0.1443907
 layout: event.html
 collection: events
 draft: true # Delete this line to publish


### PR DESCRIPTION
This PR contains the post for my upcoming talk about my side project that uses Alexa to make inaccessible websites accessible.

I've tried to follow the guides [here](https://github.com/asyncjs/async-website/wiki/Adding-an-event) and [there](https://github.com/asyncjs/async-website/blob/master/_posts/0000-01-01-_blank.md) as much as possible, and took some additional things from previous posts like the links to the meetup pages and co.

I wasn't actually sure where will the event be? Spaces?

Thanks!
