### PR TITLE
feat: Replaced Google Analytics with Fathom

### DIFF
--- a/_includes/partials/head.html
+++ b/_includes/partials/head.html
@@ -12,12 +12,7 @@
   <meta name="twitter:site" content="@asyncjs" />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600|Varela+Round&display=swap&subset=latin-ext" rel="stylesheet">
   <link rel="stylesheet" href="/css/global.css" />
-  <!-- Google Analytics -->
-  <script>
-  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-  ga('create', '{{ site.analytics }}', 'auto');
-  ga('send', 'pageview');
-  </script>
-  <script async src='//www.google-analytics.com/analytics.js'></script>
-  <!-- End Google Analytics -->
+  <!-- Fathom - beautiful, simple website analytics -->
+  <script src="https://cdn.usefathom.com/script.js" data-site="{{ site.analytics }}" defer></script>
+  <!-- / Fathom -->
 </head>

--- a/site.json
+++ b/site.json
@@ -1,11 +1,10 @@
 {
-  "title":      "Async",
+  "title": "Async",
   "description": "An inclusive web tech meetup based in Brighton, UK",
-  "caption":    "An _inclusive_ web tech meetup based in _Brighton, UK_",
-  "url":        "https://asyncjs.com",
-  "email":      "hello@asyncjs.com",
-  "feedburner": "http://feeds.feedburner.com/asyncjs",
-  "analytics":  "UA-2150808-14",
+  "caption": "An _inclusive_ web tech meetup based in _Brighton, UK_",
+  "url": "https://asyncjs.com",
+  "email": "hello@asyncjs.com",
+  "analytics": "DCQSDYFP",
   "mapbox": {
     "api_token": "pk.eyJ1IjoiYXN5bmNqcyIsImEiOiJrMHlGX3BJIn0.O57e5qvXpxKni60engPX2Q"
   },
@@ -64,14 +63,14 @@
       "desc": "Subscribe to the website's Atom feed"
     },
     {
-      "name": "Subscribe by email",
-      "link": "http://feedburner.google.com/fb/a/mailverify?uri=asyncjs",
-      "desc": "Subscribe to email updates for the website"
-    },
-    {
       "name": "Email Us",
       "link": "mailto:hello@asyncjs.com",
       "desc": "Get in touch"
+    },
+    {
+      "name": "Analytics",
+      "link": "https://app.usefathom.com/share/dcqsdyfp/asyncjs.com",
+      "desc": "Analytics powered by Fathom"
     },
     {
       "name": "Code of Conduct",


### PR DESCRIPTION
Makes us compliant with cookie regulations and improves privacy for our web traffic - the issue of a call to Google Fonts remains - the team at Fathom have kindly sponsored an Async account

Removes the now defunct 'Subscribe by email' Feedburner service in footer and replaces with a link to our public analytics dashboard